### PR TITLE
Fallback to crate_version when not in git repository

### DIFF
--- a/src/bin/dotfilers.rs
+++ b/src/bin/dotfilers.rs
@@ -10,7 +10,10 @@ const DRY_RUN_ARG: &str = "dry-run";
 const SECTIONS_ARG: &str = "sections";
 const DEFAULT_FILE_NAME: &str = "dotfilers.yaml";
 
-const VERSION: &str = git_version::git_version!(args = ["--tags", "--always", "--abbrev=1", "--dirty=-modified"]);
+const VERSION: &str = git_version::git_version!(
+    args = ["--tags", "--always", "--abbrev=1", "--dirty=-modified"],
+    fallback = clap::crate_version!()
+);
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct IsoTime;


### PR DESCRIPTION
When not building in a git repository, `git_version::git_version!()` would not
compile, because it requires to be run in a git repository to get the
current tag/branch/hash/status. [1]

This adds a fallback to the macro by using `clap::crate_version!()` which gets the
version from `Cargo.toml`.

[1] One of these situations is when running `cargo install dotfilers`
instead of cloning the repository and running `cargo build`.